### PR TITLE
Export servant client functions and runners

### DIFF
--- a/mixpanel-client.cabal
+++ b/mixpanel-client.cabal
@@ -22,6 +22,7 @@ library
   exposed-modules:
       MixPanel
       MixPanel.API
+      MixPanel.Env
       MixPanel.Types.Core
       MixPanel.Types.EngageData
       MixPanel.Types.TrackData

--- a/src/MixPanel/API.hs
+++ b/src/MixPanel/API.hs
@@ -1,19 +1,43 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE CPP #-}
 {- As per https://mixpanel.com/help/reference/http
 -}
 module MixPanel.API
-  ( API
+  ( -- * Servant API
+    API
   , api
+
+  -- * Servant client functions
+  , engageC
+  , trackC
+
+  -- * Haskell API
+  , alias
+  , engage
+  , engage'
+  , track
+
+  -- * Run the Servant clients
+  , runMixPanel
+  , MixPanelError(..)
   ) where
 
+import           Control.Exception              ( Exception )
+import           Data.Aeson                     ( Object, (.=) )
 import           Data.Text                      ( Text )
+import           GHC.Exts                       ( fromList )
 import           Data.Proxy                     ( Proxy(..) )
 import           Servant.API             hiding ( URI )
-
-import           MixPanel.Types.Core            ( DidSucceed, Toggle )
-import           MixPanel.Types.TrackData       ( TrackData )
-import           MixPanel.Types.EngageData      ( EngageData )
+import           Servant.Client                 ( client, ClientEnv, ClientError, ClientM, runClientM )
+import           MixPanel.Env                   ( Env(..) )
+import           MixPanel.Types.Core            ( DidSucceed(..)
+                                                , Toggle(..)
+                                                )
+import           MixPanel.Types.TrackData       ( TrackData(..)
+                                                , mkProperties
+                                                )
+import           MixPanel.Types.EngageData      ( EngageData, DistinctId, Operation(..), mkEngageData )
 
 
 type Track = "track"
@@ -36,3 +60,53 @@ type API = Track :<|> Engage
 
 api :: Proxy API
 api = Proxy
+
+data MixPanelError
+  = ClientError ClientError
+  | Error Text
+  deriving (Show, Exception)
+
+#if !MIN_VERSION_servant_client(0,16,0)
+#define ClientError ServantError
+#endif
+
+trackC :: TrackData -> Maybe Toggle -> Maybe Text -> Maybe Toggle -> Maybe Text -> Maybe Toggle -> ClientM DidSucceed
+engageC :: EngageData -> Maybe Text -> Maybe Text -> Maybe Toggle -> ClientM DidSucceed
+trackC :<|> engageC = client api
+
+trackC' :: TrackData -> ClientM DidSucceed
+trackC' trackdata = trackC trackdata Nothing Nothing Nothing Nothing (Just On)
+
+engageC' :: EngageData -> ClientM DidSucceed
+engageC' engagedata =
+  engageC engagedata Nothing Nothing (Just On)
+
+runMixPanel :: ClientEnv -> ClientM DidSucceed -> IO (Either MixPanelError ())
+runMixPanel clientEnv comp = do
+  result <- runClientM comp clientEnv
+  return $ case result of
+    Left err -> Left $ ClientError err
+    Right (Fail err) -> Left $ Error err
+    Right Success -> Right ()
+
+-- | Renames distinct id into alias id
+alias :: Env -> DistinctId -> Text -> IO (Either MixPanelError ())
+alias Env{..} distinctId aliasId =
+   runMixPanel clientEnv $ trackC' $ TrackData "$create_alias" $ mkProperties authtoken props
+    where
+      props :: Object
+      props = fromList [ "alias" .= aliasId
+                       , "distinct_id" .= distinctId]
+
+track :: Env -> Text -> Object -> IO (Either MixPanelError ())
+track Env{..} event props =
+  runMixPanel clientEnv $ trackC' $ TrackData event $ mkProperties authtoken props
+
+engage :: Env -> DistinctId -> Operation -> IO (Either MixPanelError ())
+engage Env{..} distinctid operation =
+  runMixPanel clientEnv $ engageC' $ mkEngageData authtoken distinctid operation
+
+engage' :: Env -> DistinctId -> (EngageData -> EngageData) -> Operation -> IO (Either MixPanelError ())
+engage' Env{..} distinctid f operation =
+  runMixPanel clientEnv $ engageC' $ f $ mkEngageData authtoken distinctid operation
+

--- a/src/MixPanel/Env.hs
+++ b/src/MixPanel/Env.hs
@@ -1,0 +1,23 @@
+module MixPanel.Env 
+  ( Env(..)
+  , mkEnv
+  ) where
+
+import           Servant.Client                 ( BaseUrl(..), ClientEnv, mkClientEnv, Scheme(..) )
+import           MixPanel.Types.Core            ( AuthToken )
+import qualified Network.HTTP.Client           as HTTP
+
+host :: BaseUrl
+host = BaseUrl Https "api.mixpanel.com" 443 ""
+
+data Env = Env
+  { authtoken :: AuthToken
+  , httpManager :: HTTP.Manager
+  , clientEnv :: ClientEnv
+  }
+
+mkEnv :: AuthToken -> HTTP.Manager -> Env
+mkEnv authtoken httpManager = Env {..}
+  where
+    clientEnv = mkClientEnv httpManager host
+

--- a/src/MixPanel/Types/TrackData.hs
+++ b/src/MixPanel/Types/TrackData.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 module MixPanel.Types.TrackData
   ( TrackData(..)
-  , Properties
+  , Properties(..)
   , mkProperties
   ) where
 

--- a/src/MixPanel/Types/TrackData.hs
+++ b/src/MixPanel/Types/TrackData.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 module MixPanel.Types.TrackData
   ( TrackData(..)
+  , mkTrackData
   , Properties(..)
   , mkProperties
   ) where
@@ -12,6 +13,7 @@ import           Data.Aeson                     ( ToJSON
                                                 , Object
                                                 , (.=)
                                                 )
+import           Data.Aeson.Types               ( Pair )
 import           Data.Text                      ( Text )
 import qualified Data.ByteString.Base64.Lazy   as B64
 import           Data.Time.Clock.POSIX          ( POSIXTime )
@@ -27,9 +29,14 @@ data TrackData = TrackData
   , properties :: Properties
   } deriving (Generic, ToJSON)
 
-
 instance ToHttpApiData TrackData where
   toUrlPiece = toS . B64.encode . encode
+
+mkTrackData :: AuthToken -> Text -> [Pair] -> TrackData
+mkTrackData token event props =
+  TrackData { event = event, properties = properties }
+  where
+    properties = mkProperties token (fromList props)
 
 data Properties = Properties
   { token :: AuthToken

--- a/src/MixPanel/Types/TrackData.hs
+++ b/src/MixPanel/Types/TrackData.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ExistentialQuantification #-}
 module MixPanel.Types.TrackData
   ( TrackData(..)
   , mkTrackData


### PR DESCRIPTION
* Export `trackC` and `engageC`.
* Export `runMixPanel` to run the above client functions.
* Re-export `DidSucceed` and `Toggle` types for easy access.
* Expose the constructor for `Properties`.
* Add `mkTrackData` to match the `mkEngageData` API.